### PR TITLE
Allow user to control number of steps run at once

### DIFF
--- a/thresholds/stability.py
+++ b/thresholds/stability.py
@@ -1,12 +1,26 @@
 from simtk import unit
 
 
-def check_stability(simulation, n_steps=1000, potential_energy_threshold=1000 * unit.kilojoule_per_mole):
+def check_stability(simulation, n_steps=1000, n_rounds=10, potential_energy_threshold=1000 * unit.kilojoule_per_mole):
     """Run simulation for n_steps, periodically checking if the potential energy exceeds a threshold.
-    If the potential energy ever exceeds the threshold or becomes NaN, terminate and return False."""
+    If the potential energy ever exceeds the threshold or becomes NaN, terminate and return False.
+    
+    Parameters
+    ----------
+    simulation : openmm.app.Simulation
+        simulation whose stability we are studying
+    n_steps : int, default 1000
+        how many timesteps to simulate
+    n_rounds : int, default 10
+        how many rounds to use to run n_steps
+        e.g. if n_steps is 1000, specifying n_rounds as 10 will run 10 rounds of 100 steps
+    potential_energy_threshold : simtk.unit (energy)
+        if the potential energy of the simulation exceeds this threshold, NaNs are nigh
 
-    for _ in range(round(n_steps / 100)):
-        simulation.step(100)
+    """
+
+    for _ in range(round(n_rounds)):
+        simulation.step(round(n_steps / n_rounds))
         potential_energy = simulation.context.getState(getEnergy=True).getPotentialEnergy()
         if not (potential_energy <= potential_energy_threshold):
             return False

--- a/thresholds/stability.py
+++ b/thresholds/stability.py
@@ -19,7 +19,7 @@ def check_stability(simulation, n_steps=1000, n_rounds=10, potential_energy_thre
 
     """
 
-    for _ in range(round(n_rounds)):
+    for _ in range(n_rounds):
         simulation.step(round(n_steps / n_rounds))
         potential_energy = simulation.context.getState(getEnergy=True).getPotentialEnergy()
         if not (potential_energy <= potential_energy_threshold):


### PR DESCRIPTION
I applied this package to one of my fah projects that has a high failure rate using [the HMR stability example](https://github.com/choderalab/thresholds/blob/master/examples/hmr_stability.py). I got an exception — `Particle coordinate is nan` at this [line](https://github.com/choderalab/thresholds/blob/master/thresholds/stability.py#L9), so I changed it to `simulation.step(1)`, which enabled me to run simulation experiments smoothly. It would be nice for the user to be able to control this, so I've added an argument to `check_stability` to enable users to specify how many rounds (`n_rounds` they would like to split `n_steps` into. In my case, if `n_steps=1000`, I would specify `n_rounds=1000`.